### PR TITLE
Fix Java interop imports

### DIFF
--- a/eta-jdbc.cabal
+++ b/eta-jdbc.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                eta-jdbc
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            JDBC Bindings Eta
 -- description:
 license:             Apache-2.0
@@ -47,6 +47,7 @@ library
                        RankNTypes
                        AllowAmbiguousTypes
                        ScopedTypeVariables
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && <4.9,
+                       eta-java-interop
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/JDBC/Types/Blob.hs
+++ b/src/JDBC/Types/Blob.hs
@@ -13,7 +13,7 @@ module JDBC.Types.Blob
 where
 
 import Java
-import Java.IO
+import Interop.Java.IO
 import JDBC.Types
 
 foreign import java unsafe "@interface free" freeBlob :: Java Blob () --Todo

--- a/src/JDBC/Types/CallableStatement.hs
+++ b/src/JDBC/Types/CallableStatement.hs
@@ -112,10 +112,10 @@ module JDBC.Types.CallableStatement
 where
 
 import Java
-import Java.DateTime
-import Java.IO
+import Interop.Java.DateTime
+import Interop.Java.IO
 import Java.Math
-import Java.Net
+import Interop.Java.Net
 import JDBC.Types
 
 foreign import java unsafe "@interface getArray" getArrayCallableStatement ::

--- a/src/JDBC/Types/Clob.hs
+++ b/src/JDBC/Types/Clob.hs
@@ -15,7 +15,7 @@ module JDBC.Types.Clob
 where
 
 import Java
-import Java.IO
+import Interop.Java.IO
 import JDBC.Types
 
 foreign import java unsafe "@interface free" freeClob :: Java Clob ()

--- a/src/JDBC/Types/ResultSet.hs
+++ b/src/JDBC/Types/ResultSet.hs
@@ -188,10 +188,10 @@ module JDBC.Types.ResultSet
 where
 
 import Java
-import Java.DateTime
-import Java.IO
+import Interop.Java.DateTime
+import Interop.Java.IO
 import Java.Math
-import Java.Net
+import Interop.Java.Net
 import JDBC.Types
 
 foreign import java unsafe "@interface absolute" absoluteResultSet :: Int -> Java ResultSet Bool

--- a/src/JDBC/Types/SQLInput.hs
+++ b/src/JDBC/Types/SQLInput.hs
@@ -29,10 +29,10 @@ module JDBC.Types.SQLInput
 where
 
 import Java
-import Java.DateTime
-import Java.IO
+import Interop.Java.DateTime
+import Interop.Java.IO
 import Java.Math
-import Java.Net
+import Interop.Java.Net
 import JDBC.Types
 
 foreign import java unsafe "@interface readArray" readArraySQLInput :: Java SQLInput Array

--- a/src/JDBC/Types/SQLOutput.hs
+++ b/src/JDBC/Types/SQLOutput.hs
@@ -28,10 +28,10 @@ module JDBC.Types.SQLOutput
 where
 
 import Java
-import Java.DateTime
-import Java.IO
+import Interop.Java.DateTime
+import Interop.Java.IO
 import Java.Math
-import Java.Net
+import Interop.Java.Net
 import JDBC.Types
 
 foreign import java unsafe "@interface writeArray" writeArraySQLOutput :: Array -> Java SQLOutput ()

--- a/src/JDBC/Types/SQLXML.hs
+++ b/src/JDBC/Types/SQLXML.hs
@@ -1,7 +1,7 @@
 module JDBC.Types.SQLXML where
 
 import Java
-import Java.IO
+import Interop.Java.IO
 import JDBC.Types
 
 foreign import java unsafe "@interface free" freeSQLXML :: Java SQLXML ()

--- a/src/JDBC/Types/Timestamp.hs
+++ b/src/JDBC/Types/Timestamp.hs
@@ -1,7 +1,7 @@
 module JDBC.Types.Timestamp where
 
 import Java
-import Java.DateTime
+import Interop.Java.DateTime
 import JDBC.Types
 
 foreign import java unsafe "after" afterTimestamp :: Timestamp -> Java Timestamp Bool


### PR DESCRIPTION
In the latest Eta versions `Java.IO`, `Java.DateTime` and `Java.Net` are not included in
base and rather, they were moved to `eta-java-interop`. This commit fixes that so this
package works in the newer versions of Eta.